### PR TITLE
Add support for conditionally storing intermediate outputs in dual_gemm.

### DIFF
--- a/xformers/csrc/swiglu/cuda/dual_gemm_silu_identity_mul.cu
+++ b/xformers/csrc/swiglu/cuda/dual_gemm_silu_identity_mul.cu
@@ -71,9 +71,9 @@ std::tuple<at::Tensor, at::Tensor> dual_gemm_silu_identity_mul_(
   using WarpShape = cutlass::gemm::GemmShape<64, 32, 32>;
   using InstructionShape = cutlass::gemm::GemmShape<16, 8, 16>;
 
-  // Optionally, we might not need intermediate GEMM outputs
-  constexpr bool kStoreD0 = true;
-  constexpr bool kStoreD1 = true;
+  // For a fused kernel we don't need the intermediate outputs. 
+  constexpr bool kStoreD0 = false;
+  constexpr bool kStoreD1 = false;
   using ArchTag = cutlass::arch::Sm80;
 
   using DualGemm = cutlass::gemm::device::DualGemm<
@@ -134,14 +134,14 @@ std::tuple<at::Tensor, at::Tensor> dual_gemm_silu_identity_mul_(
           typename DualGemm::LayoutB0::Stride(w0.stride(0))},
       ref_b0,
       RefC{
-          (scalar_t*)d0.data_ptr(),
+          (kStoreD0 ? (scalar_t*)d0.data_ptr() : nullptr),
           typename DualGemm::LayoutC::Stride(d0.stride(0))},
       RefB1{
           (scalar_t*)w1.data_ptr(),
           typename DualGemm::LayoutB1::Stride(w1.stride(0))},
       ref_b1,
       RefC{
-          (scalar_t*)d1.data_ptr(),
+          (kStoreD1 ? (scalar_t*)d1.data_ptr() : nullptr),
           typename DualGemm::LayoutC::Stride(d1.stride(0))},
       RefC{
           (scalar_t*)d2.data_ptr(),
@@ -162,7 +162,10 @@ std::tuple<at::Tensor, at::Tensor> dual_gemm_silu_identity_mul_(
   status = dual_gemm.initialize(arguments, (uint8_t*)workspace.data_ptr());
   TORCH_CHECK(status == cutlass::Status::kSuccess, "kernel initialize failed");
   status = dual_gemm(stream);
-  TORCH_CHECK(status == cutlass::Status::kSuccess, "kernel run failed: ", cutlass::cutlassGetStatusString(status));
+  TORCH_CHECK(
+      status == cutlass::Status::kSuccess,
+      "kernel run failed: ",
+      cutlass::cutlassGetStatusString(status));
   return std::make_tuple(d0d1, d2);
 }
 
@@ -188,8 +191,7 @@ std::tuple<at::Tensor, at::Tensor> dual_gemm_silu_identity_mul(
   }
 }
 
-std::tuple<at::Tensor, at::Tensor>
-dual_gemm_silu_identity_mul_autocast(
+std::tuple<at::Tensor, at::Tensor> dual_gemm_silu_identity_mul_autocast(
     const at::Tensor& x,
     const at::Tensor& w0,
     const c10::optional<at::Tensor>& b0,


### PR DESCRIPTION
At the moment we write the intermediate results back to memory. 

This isn't actually needed, because the fused operation doesn't use those values anyway:

https://github.com/poolsideai/xformers/blob/6ad9729b7f527a7fdb9985b67b93ecbdb98e1211/xformers/ops/swiglu_op.py#L108

i.e the `x * w0 + b0` and `x * w1 + b1` values aren't actually needed or used.

The guards on the output pointers are to prevent cutlass from complaining, as it expects the output pointers to be null if there's no storage option set, see e.g [this](https://github.com/NVIDIA/cutlass/blob/4082fed85a7022a6a79b899796735aa7772994da/examples/45_dual_gemm/device/dual_gemm.h#L315). Maybe we should just fix this upstream instead...

This seems to make things somewhat faster: it drops the backwards time by about 5%. 