### PR TITLE
Reparameterize layer norm to avoid issues with weight decay

### DIFF
--- a/xformers/triton/k_layer_norm.py
+++ b/xformers/triton/k_layer_norm.py
@@ -48,7 +48,7 @@ def layer_norm_fw(X, Y, W, B, M, V, stride, N, eps, affine: tl.constexpr, BLOCK_
     if affine:
         w = tl.load(W + cols, mask=mask, other=1.0)
         b = tl.load(B + cols, mask=mask, other=0.0)
-        y = y * w + b
+        y = y * (1 + w) + b
 
     y_ptrs = Y + row * stride + cols
     tl.store(y_ptrs, y, mask=mask)
@@ -88,7 +88,7 @@ def layer_norm_bwd_dx_fused(
 
     if affine:
         w = tl.load(W + cols, mask=mask, other=0)
-        wdy = w * dy
+        wdy = (1 + w) * dy
     else:
         wdy = dy
 

--- a/xformers/triton/k_layer_norm.py
+++ b/xformers/triton/k_layer_norm.py
@@ -7,6 +7,10 @@
 # CREDITS: This comes almost as-is from the Triton layer norm tutorial
 # https://github.com/openai/triton/blob/master/python/tutorials/05-layer-norm.py
 
+# See the following for a modification for use with weight decay that is implemented here.
+# https://medium.com/@ohadrubin/exploring-weight-decay-in-layer-normalization-challenges-and-a-reparameterization-solution-ad4d12c24950
+
+
 
 import triton
 import triton.language as tl
@@ -21,7 +25,7 @@ def layer_norm_fw(X, Y, W, B, M, V, stride, N, eps, affine: tl.constexpr, BLOCK_
     The layer norm is applied over the last dimension.
 
     Compute
-        y = (x - E(x))/(sqrt(var(x) + epsilon)) * gamma + beta
+        y = (x - E(x))/(sqrt(var(x) + epsilon)) * (1 + gamma) + beta
     """
 
     row = tl.program_id(0)

--- a/xformers/triton/k_layer_norm.py
+++ b/xformers/triton/k_layer_norm.py
@@ -50,7 +50,7 @@ def layer_norm_fw(X, Y, W, B, M, V, stride, N, eps, affine: tl.constexpr, BLOCK_
 
     mask = cols < N
     if affine:
-        w = tl.load(W + cols, mask=mask, other=1.0)
+        w = tl.load(W + cols, mask=mask, other=0.0)
         b = tl.load(B + cols, mask=mask, other=0.0)
         y = y * (1 + w) + b
 

--- a/xformers/triton/layer_norm.py
+++ b/xformers/triton/layer_norm.py
@@ -183,7 +183,7 @@ class FusedLayerNorm(nn.Module):
     def __init__(self, normalized_shape, affine=True, eps=1e-06):
         super().__init__()
         if affine:
-            self.weight = nn.Parameter(torch.ones(normalized_shape))
+            self.weight = nn.Parameter(torch.zeros(normalized_shape))
             self.bias = nn.Parameter(torch.zeros(normalized_shape))
         else:
             self.weight = self.bias = None
@@ -235,9 +235,10 @@ def layer_norm(
             logger.warning(e)
 
     if y is None:
-        y = torch.nn.functional.layer_norm(
-            x, [x.shape[-1]], weight=weight, bias=bias, eps=eps
-        )
+        #y = torch.nn.functional.layer_norm(
+        #    x, [x.shape[-1]], weight=weight, bias=bias, eps=eps
+        #)
+        raise RuntimeError("Fallback to pytorch layer norm no longer supported")
 
     assert y.dtype == input_dtype
     return y


### PR DESCRIPTION
This PR implements a reparameterization of layer norm as described in https://medium.com/@ohadrubin/exploring-weight-decay-in-layer-normalization-challenges-and-a-reparameterization-solution-ad4d12c24950

I would appreciate a thorough review of this as it is easy to overlook details especially with the optimized triton implementation.

It was clear this was not implemented in `FusedLayerNorm` because `gamma` aka `weight` is initialized to all 1s.

The following graph shows 1000 steps of training with and without the changes.

![with fix and original](https://github.com/poolsideai/xformers/assets/5234400/6361f882-b6fe-41b3-9884-890479282f90)

To quote the article on the implementation...

"To address the challenges of applying weight decay to LayerNorm parameters, a reparameterization solution can be employed to facilitate the use of weight decay without introducing bias. The reparameterization involves redefining the scale parameter as `scale = 1 + gamma`. This modification ensures that gamma remains centered around zero, mitigating the bias towards smaller scale values that may occur when applying weight decay directly to the original gamma parameter.

The reparameterization affects the initial values of the scale and gamma parameters. With the original LayerNorm, gamma is initialized to ones, resulting in an initial scale of 1. Under the reparameterized LayerNorm, gamma is initialized to zeros, and since `scale = 1 + gamma`, the initial scale remains 1, effectively preserving the identity function behavior of LayerNorm at the beginning of training. Consequently, the reparameterization maintains the desirable properties of the original LayerNorm initialization while providing a more suitable foundation for applying weight decay.

The benefits of this reparameterization are manifold. Firstly, it allows for the application of weight decay without introducing bias towards smaller scale values, as gamma is now centered around zero. This enables the network to learn the true scale and shift of the data distribution more effectively, without the limitations imposed by weight decay bias. Secondly, the reparameterization makes it possible to harness the advantages of both weight decay and LayerNorm, potentially leading to improved performance and generalization. By mitigating the bias introduced by weight decay on LayerNorm parameters, the reparameterization solution offers a more robust approach to combining these powerful techniques in deep learning models"