### PR TITLE
Fused dropout in multi head attention

### DIFF
--- a/xformers/components/multi_head_dispatch.py
+++ b/xformers/components/multi_head_dispatch.py
@@ -13,9 +13,10 @@ import torch.nn as nn
 from torch.nn.init import constant_
 
 from xformers.components.attention import Attention
-from xformers.triton import FusedDropoutBias
-from xformers.components.input_projection import InputProjection, InputProjectionConfig
+from xformers.components.input_projection import (InputProjection,
+                                                  InputProjectionConfig)
 from xformers.components.positional_embedding import RotaryEmbedding
+from xformers.triton import FusedDropoutBias
 
 logger = logging.getLogger("xformers")
 

--- a/xformers/components/multi_head_dispatch.py
+++ b/xformers/components/multi_head_dispatch.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 from torch.nn.init import constant_
 
 from xformers.components.attention import Attention
+from xformers.triton import FusedDropoutBias
 from xformers.components.input_projection import InputProjection, InputProjectionConfig
 from xformers.components.positional_embedding import RotaryEmbedding
 
@@ -141,7 +142,7 @@ class MultiHeadDispatch(nn.Module):
         )
 
         # Regularization
-        self.resid_drop = nn.Dropout(residual_dropout, inplace=True)
+        self.resid_drop = FusedDropoutBias(p=residual_dropout, bias_shape=None, inplace_fwd=True)
 
         # Output projection
         self.proj = (


### PR DESCRIPTION
Fused dropout in multi head attention is twice as fast as the torch implementation. However, this barely makes any difference to the overall efficiency of the forward pass as it reduces GPU time from 26 microseconds to 13 microseconds for the operation. Training loss behaves similarly to before the change.