### PR TITLE
Make xFormerEncoderBlock forward parameters compatible with xFormerEncoderBlock forward parameters

### DIFF
--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -130,7 +130,12 @@ class xFormerEmbeddingBlock(torch.nn.Module):
     def from_config(cls, config: xFormerEncoderConfig, **kwargs):
         return cls(config, **kwargs)
 
-    def forward(self, x: torch.Tensor, *args, **kwargs):
+    def forward(
+        self,
+        x: torch.Tensor,
+        att_mask: Optional[Union[torch.Tensor, AttentionMask]] = None,
+        input_mask: Optional[torch.Tensor] = None,
+    ):
         if self.patch_emb is not None:
             x = self.patch_emb(x)
 

--- a/xformers/factory/block_factory.py
+++ b/xformers/factory/block_factory.py
@@ -130,7 +130,7 @@ class xFormerEmbeddingBlock(torch.nn.Module):
     def from_config(cls, config: xFormerEncoderConfig, **kwargs):
         return cls(config, **kwargs)
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor, *args, **kwargs):
         if self.patch_emb is not None:
             x = self.patch_emb(x)
 


### PR DESCRIPTION
The interfaces have to be compatible because of this: https://github.com/poolsideai/xformers/blob/82200deab95daf103e03ca793a1417d734d91ea1/xformers/factory/model_factory.py#L291-L292

An error was encountered while trying to run `train_ddp.py`:
```
  ...
  File "/home/razvan/work/xformers/xformers/factory/model_factory.py", line 292, in forward
    memory = encoder(memory, input_mask=encoder_input_mask)
  File "/home/razvan/.pyenv/versions/foundation-model/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/razvan/.pyenv/versions/foundation-model/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
TypeError: xFormerEmbeddingBlock.forward() got an unexpected keyword argument 'input_mask'
```