### PR TITLE
Update init_weights to return the # of initializations

### DIFF
--- a/xformers/components/lora.py
+++ b/xformers/components/lora.py
@@ -41,7 +41,7 @@ class LoRA(nn.Module):
         y = self.matmul(y, self.low_to_high_b.weight)
         return y
 
-    def init_weights(self) -> None:
+    def init_weights(self) -> int:
         match self.init:
             case "none":
                 pass
@@ -71,6 +71,7 @@ class LoRA(nn.Module):
                     param.mul_(ratio)
                 self.high_to_low_a.weight.copy_(high_to_low_a)
                 self.low_to_high_b.weight.copy_(low_to_high_b)
+                return 2
             case "zero_b" | "almost_zero_b":
                 for param, scale in (
                     (self.high_to_low_a, 1),
@@ -89,5 +90,7 @@ class LoRA(nn.Module):
                         a=-2,
                         b=2,
                     )
+                return 2
             case _:
                 raise AssertionError(f"Unsupported LoRA initialization: {self.init}")
+        return 0

--- a/xformers/triton/dropout.py
+++ b/xformers/triton/dropout.py
@@ -246,10 +246,12 @@ class FusedDropoutBias(torch.nn.Module):
         self.inplace_fwd = inplace_fwd
         self.inplace_bwd = inplace_bwd
 
-    def init_weights(self, *args, **kwargs):
-        with torch.no_grad():
-            if self.bias is not None:
-                self.bias.fill_(0.0)
+    @torch.no_grad()
+    def init_weights(self, *args, **kwargs) -> int:
+        if self.bias is not None:
+            self.bias.fill_(0.0)
+            return 1
+        return 0
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # Convenience, catch a possible type or device mismatch

--- a/xformers/triton/layer_norm.py
+++ b/xformers/triton/layer_norm.py
@@ -206,13 +206,18 @@ class FusedLayerNorm(nn.Module):
             grad_dtype = None
         return layer_norm(x, self.weight, self.bias, self.epsilon, grad_dtype)
 
-    def init_weights(self, *args, **kwargs):
-        with torch.no_grad():
-            if self.weight is not None:
-                self.weight.fill_(1.0)
+    @torch.no_grad()
+    def init_weights(self, *args, **kwargs) -> int:
+        count = 0
+        if self.weight is not None:
+            self.weight.fill_(1.0)
+            count += 1
 
-            if self.bias is not None:
-                self.bias.fill_(0.0)
+        if self.bias is not None:
+            self.bias.fill_(0.0)
+            count += 1
+
+        return count
 
 
 def layer_norm(


### PR DESCRIPTION
Avoid this warning

```python
WARNING:9dff:py.warnings:/home/ubuntu/carlos/foundation-model/poolside/monster/common_model.py:537: UserWarning: `FusedLayerNorm.init_weights` should return the number of parameters that were initialized. Please update its implementation
  warnings.warn(

WARNING:9dff:py.warnings:/home/ubuntu/carlos/foundation-model/poolside/monster/common_model.py:537: UserWarning: `FusedDropoutBias.init_weights` should return the number of parameters that were initialized. Please update its implementation
  warnings.warn(
```


That would appear after https://github.com/poolsideai/foundation-model/pull/1020 is merged